### PR TITLE
Keep project under GPLv3

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -79,7 +79,7 @@ These experiments verify that runtime redefinition works and that the pipeline f
    - Set up a CI pipeline (GitHub Actions) for build and release automation.
 
 6. **Licensing & Packaging**
-   - Define a permissive license for open-source usage while reserving rights for premium features.
+   - Use the [GNU General Public License version 3](https://www.gnu.org/licenses/gpl-3.0.txt) for the open-source components while reserving rights for premium features.
    - Publish artifacts to Maven Central for easy consumption.
 
 7. **Polished Product**

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <inceptionYear>2025</inceptionYear>
   <licenses>
     <license>
-      <name>GPL</name>
-      <url>http://www.fsf.org/licensing/licenses/gpl.html</url>
+      <name>GNU General Public License v3.0</name>
+      <url>https://www.gnu.org/licenses/gpl-3.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
## Summary
- revert Apache license switch, restoring GPLv3 text
- clarify GPLv3 usage in the design document
- reference GPLv3 explicitly in Maven pom

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: could not resolve maven-resources-plugin)*


------
https://chatgpt.com/codex/tasks/task_b_684325f3af188332adbbfd3b6884586d