### PR TITLE
Add basic CLI command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ This repository aims to build a command-line tool capable of reloading changed c
 
 See [docs/design.md](docs/design.md) for the architecture sketch, proof-of-concept checklist and growth plan.
 
+## Command Line Interface
+
+Run the CLI to manually trigger reloads:
+
+```
+java -cp <jar-with-dependencies> org.acmsl.hotswap.cli.ReloadCLI
+```
+
+The following commands are available:
+
+* `reload <class-name> <class-file>` – redefine a loaded class with the supplied class file bytes.
+* `quit` – exit the CLI.
+
+For example:
+
+```
+> reload com.example.MyService target/classes/com/example/MyService.class
+> quit
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
       <artifactId>byte-buddy</artifactId>
       <version>1.14.1</version>
     </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-agent</artifactId>
+      <version>1.14.1</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/org/acmsl/hotswap/cli/ReloadCLI.java
+++ b/src/main/java/org/acmsl/hotswap/cli/ReloadCLI.java
@@ -1,12 +1,70 @@
 package org.acmsl.hotswap.cli;
 
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Scanner;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.acmsl.hotswap.reloader.Reloader;
+
 /**
- * Placeholder command-line interface. For now it only prints a startup message.
+ * Simple command-line interface for manually triggering reloads.
  */
 public final class ReloadCLI {
     private ReloadCLI() {}
 
-    public static void main(String[] args) {
-        System.out.println("Java-Hotswap CLI - TODO: implement commands");
+    /**
+     * Starts the CLI loop and listens for commands.
+     *
+     * Supported commands:
+     * <ul>
+     *   <li>{@code reload &lt;class-name&gt; &lt;class-file&gt;}</li>
+     *   <li>{@code quit}</li>
+     * </ul>
+     */
+    public static void main(String[] args) throws Exception {
+        System.out.println("Java-Hotswap CLI");
+
+        // Obtain an Instrumentation instance by attaching a Byte Buddy agent
+        Instrumentation inst = ByteBuddyAgent.install();
+        Reloader reloader = new Reloader(inst);
+        reloader.start();
+
+        Scanner scanner = new Scanner(System.in);
+        while (true) {
+            System.out.print("> ");
+            String line = scanner.nextLine().trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            String[] parts = line.split("\\s+");
+            String command = parts[0].toLowerCase();
+            switch (command) {
+                case "reload" -> {
+                    if (parts.length < 3) {
+                        System.out.println("Usage: reload <class-name> <class-file>");
+                        continue;
+                    }
+
+                    String className = parts[1];
+                    String file = parts[2];
+                    try {
+                        byte[] bytes = Files.readAllBytes(Paths.get(file));
+                        Class<?> type = Class.forName(className);
+                        reloader.reloadClass(type, bytes);
+                        System.out.println("Reloaded " + className);
+                    } catch (Exception e) {
+                        System.err.println("Failed to reload " + className + ": " + e.getMessage());
+                    }
+                }
+                case "quit" -> {
+                    System.out.println("Exiting...");
+                    return;
+                }
+                default -> System.out.println("Unknown command: " + command);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement command loop for ReloadCLI
- attach Byte Buddy Agent and reload classes
- document reload/quit CLI commands
- include byte-buddy-agent dependency

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_684328a5db988332a27722a667436fcd