### PR TITLE
Add YAML watch config parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
       <version>1.14.1</version>
     </dependency>
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>2.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.10.2</version>

--- a/src/main/java/org/acmsl/hotswap/config/FolderWatch.java
+++ b/src/main/java/org/acmsl/hotswap/config/FolderWatch.java
@@ -1,0 +1,23 @@
+package org.acmsl.hotswap.config;
+
+/** Simple POJO representing a folder to watch and the polling interval in milliseconds. */
+public class FolderWatch {
+    private String path;
+    private long interval;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+}

--- a/src/main/java/org/acmsl/hotswap/config/WatcherConfiguration.java
+++ b/src/main/java/org/acmsl/hotswap/config/WatcherConfiguration.java
@@ -1,0 +1,29 @@
+package org.acmsl.hotswap.config;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.yaml.snakeyaml.Yaml;
+
+/** Parses YAML configuration describing folders to watch. */
+public class WatcherConfiguration {
+    private List<FolderWatch> folders;
+
+    public List<FolderWatch> getFolders() {
+        return folders;
+    }
+
+    public void setFolders(List<FolderWatch> folders) {
+        this.folders = folders;
+    }
+
+    /** Load configuration from a YAML file. */
+    public static WatcherConfiguration load(Path path) throws Exception {
+        try (InputStream is = Files.newInputStream(path)) {
+            Yaml yaml = new Yaml();
+            return yaml.loadAs(is, WatcherConfiguration.class);
+        }
+    }
+}

--- a/src/test/java/org/acmsl/hotswap/config/WatcherConfigurationTest.java
+++ b/src/test/java/org/acmsl/hotswap/config/WatcherConfigurationTest.java
@@ -1,0 +1,33 @@
+package org.acmsl.hotswap.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class WatcherConfigurationTest {
+    @Test
+    public void parsesFoldersAndIntervals() throws Exception {
+        String yaml = """
+        folders:
+          - path: /tmp/foo
+            interval: 1000
+          - path: /tmp/bar
+            interval: 2000
+        """;
+        Path file = Files.createTempFile("watch", ".yml");
+        Files.writeString(file, yaml);
+
+        WatcherConfiguration config = WatcherConfiguration.load(file);
+        assertNotNull(config);
+        List<FolderWatch> folders = config.getFolders();
+        assertEquals(2, folders.size());
+        assertEquals("/tmp/foo", folders.get(0).getPath());
+        assertEquals(1000, folders.get(0).getInterval());
+        assertEquals("/tmp/bar", folders.get(1).getPath());
+        assertEquals(2000, folders.get(1).getInterval());
+    }
+}


### PR DESCRIPTION
## Summary
- add SnakeYAML dependency
- implement `FolderWatch` and `WatcherConfiguration` classes
- test parsing of watched folders and polling interval from YAML

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68433eacb984833288a875cab6562f13