### PR TITLE
Implement ReloaderCLI config validation

### DIFF
--- a/src/main/java/org/acmsl/hotswap/cli/ReloaderCLI.java
+++ b/src/main/java/org/acmsl/hotswap/cli/ReloaderCLI.java
@@ -1,0 +1,62 @@
+package org.acmsl.hotswap.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.acmsl.hotswap.config.WatcherConfiguration;
+
+/**
+ * CLI that loads a watch configuration and starts reloading service.
+ */
+public final class ReloaderCLI {
+    private ReloaderCLI() {}
+
+    /**
+     * Entry point for the reloader CLI.
+     *
+     * @param args ignored
+     */
+    public static void main(String[] args) throws Exception {
+        run();
+    }
+
+    /**
+     * Executes the CLI logic. Returns {@code true} if startup succeeded.
+     */
+    static boolean run() throws Exception {
+        String configPath = System.getProperty("jhsconfig");
+        if (configPath == null || configPath.isBlank()) {
+            System.err.println("Missing required system property jhsconfig");
+            return false;
+        }
+
+        if (!(configPath.endsWith(".yml") || configPath.endsWith(".yaml"))) {
+            System.err.println("Configuration file must be .yml or .yaml");
+            return false;
+        }
+
+        Path path = Path.of(configPath);
+        if (!Files.exists(path)) {
+            System.err.println("Configuration file " + configPath + " does not exist");
+            return false;
+        }
+
+        WatcherConfiguration config;
+        try {
+            config = WatcherConfiguration.load(path);
+        } catch (Exception e) {
+            System.err.println("Failed to load configuration: " + e.getMessage());
+            return false;
+        }
+
+        if (config == null || config.getFolders() == null || config.getFolders().isEmpty()) {
+            System.err.println("Configuration must define at least one folder to watch");
+            return false;
+        }
+
+        System.out.println(
+                "Loaded configuration for " + config.getFolders().size() + " folder(s)");
+        // In a full implementation watchers would be started here
+        return true;
+    }
+}

--- a/src/test/java/org/acmsl/hotswap/cli/ReloaderCLITest.java
+++ b/src/test/java/org/acmsl/hotswap/cli/ReloaderCLITest.java
@@ -1,0 +1,38 @@
+package org.acmsl.hotswap.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class ReloaderCLITest {
+    @AfterEach
+    public void clearProperty() {
+        System.clearProperty("jhsconfig");
+    }
+
+    @Test
+    public void exitsWhenPropertyMissing() throws Exception {
+        System.clearProperty("jhsconfig");
+        assertFalse(ReloaderCLI.run());
+    }
+
+    @Test
+    public void exitsWhenFileNotYaml() throws Exception {
+        Path file = Files.createTempFile("config", ".txt");
+        System.setProperty("jhsconfig", file.toString());
+        assertFalse(ReloaderCLI.run());
+    }
+
+    @Test
+    public void exitsWhenNoFoldersConfigured() throws Exception {
+        String yaml = "folders: []";
+        Path file = Files.createTempFile("config", ".yml");
+        Files.writeString(file, yaml);
+        System.setProperty("jhsconfig", file.toString());
+        assertFalse(ReloaderCLI.run());
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `ReloaderCLI` that reads configuration from `-Djhsconfig`
- fail fast when the property is missing, the file is not YAML, or no folders are configured
- test these failure modes in `ReloaderCLITest`

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_b_6843410b0f3483328b9481b987624e76