### PR TITLE
Add agent server socket integration test

### DIFF
--- a/src/test/java/org/acmsl/hotswap/agent/AgentServerSocketTest.java
+++ b/src/test/java/org/acmsl/hotswap/agent/AgentServerSocketTest.java
@@ -1,0 +1,57 @@
+package org.acmsl.hotswap.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class AgentServerSocketTest {
+    private Process process;
+
+    @AfterEach
+    public void tearDown() {
+        if (process != null) {
+            process.destroy();
+            try {
+                process.waitFor();
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
+
+    @Test
+    public void agentOpensServerSocket() throws Exception {
+        String java = System.getProperty("java.home") + "/bin/java";
+        String classpath = System.getProperty("java.class.path");
+        ProcessBuilder pb = new ProcessBuilder(java, "-cp", classpath,
+                "org.acmsl.hotswap.test.AgentRunner");
+        pb.redirectErrorStream(true);
+        process = pb.start();
+
+        long deadline = System.currentTimeMillis() + 10000;
+        boolean connected = false;
+        while (!connected && System.currentTimeMillis() < deadline) {
+            try (Socket s = new Socket()) {
+                s.connect(new InetSocketAddress("localhost", 62345), 100);
+                connected = true;
+            } catch (Exception e) {
+                Thread.sleep(100);
+            }
+        }
+        assertTrue(connected, "server did not start");
+
+        try (Socket s = new Socket("localhost", 62345);
+             PrintWriter out = new PrintWriter(s.getOutputStream(), true);
+             BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream()))) {
+            out.println("refresh /tmp");
+            String resp = in.readLine();
+            assertEquals("OK", resp);
+        }
+    }
+}

--- a/src/test/java/org/acmsl/hotswap/test/AgentRunner.java
+++ b/src/test/java/org/acmsl/hotswap/test/AgentRunner.java
@@ -1,0 +1,14 @@
+package org.acmsl.hotswap.test;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.acmsl.hotswap.agent.AgentBootstrap;
+
+public class AgentRunner {
+    public static void main(String[] args) throws Exception {
+        var inst = ByteBuddyAgent.install();
+        AgentBootstrap.premain("", inst);
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- start server socket on port `62345` when the `Reloader` starts
- add helper `AgentRunner` test main
- add integration test ensuring the agent socket accepts `refresh` command

## Testing
- `mvn test` *(fails: could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68434538988883328a9d3ac13d6bda8a