### PR TITLE
Improve FolderWatch with threaded detection and test

### DIFF
--- a/src/main/java/org/acmsl/hotswap/config/FolderWatch.java
+++ b/src/main/java/org/acmsl/hotswap/config/FolderWatch.java
@@ -1,9 +1,21 @@
 package org.acmsl.hotswap.config;
 
-/** Simple POJO representing a folder to watch and the polling interval in milliseconds. */
-public class FolderWatch {
+/**
+ * Represents a folder to watch and the polling interval in milliseconds.
+ * <p>
+ * Besides being a simple configuration holder, this class can actively watch a
+ * directory for changes. When {@link #watch(Runnable)} is invoked a dedicated
+ * daemon thread is started which checks the folder contents every
+ * {@code interval} milliseconds.  Whenever a change is detected the provided
+ * callback is executed.
+ */
+public class FolderWatch implements Runnable {
     private String path;
     private long interval;
+
+    private volatile boolean running;
+    private Thread thread;
+    private Runnable callback;
 
     public String getPath() {
         return path;
@@ -19,5 +31,42 @@ public class FolderWatch {
 
     public void setInterval(long interval) {
         this.interval = interval;
+    }
+
+    /** Starts watching the configured folder on a separate daemon thread. */
+    public void watch(Runnable callback) {
+        this.callback = callback;
+        running = true;
+        thread = new Thread(this, "FolderWatch-" + path);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    /** Stops watching the folder. */
+    public void stop() {
+        running = false;
+        if (thread != null) {
+            thread.interrupt();
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            java.nio.file.Path dir = java.nio.file.Path.of(path);
+            java.util.Set<java.nio.file.Path> snapshot = java.nio.file.Files.list(dir).collect(java.util.stream.Collectors.toSet());
+            while (running) {
+                Thread.sleep(interval);
+                java.util.Set<java.nio.file.Path> current = java.nio.file.Files.list(dir).collect(java.util.stream.Collectors.toSet());
+                if (!current.equals(snapshot)) {
+                    snapshot = current;
+                    if (callback != null) {
+                        callback.run();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // swallow exceptions for now - this is a simple utility used in tests
+        }
     }
 }

--- a/src/test/java/org/acmsl/hotswap/config/FolderWatchTest.java
+++ b/src/test/java/org/acmsl/hotswap/config/FolderWatchTest.java
@@ -1,0 +1,38 @@
+package org.acmsl.hotswap.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+public class FolderWatchTest {
+    @Test
+    public void detectsChangesOnSeparateThread() throws Exception {
+        Path dir = Files.createTempDirectory("fw");
+        long interval = 1000 + (long)(Math.random() * 500);
+        FolderWatch watch = new FolderWatch();
+        watch.setPath(dir.toString());
+        watch.setInterval(interval);
+
+        AtomicBoolean detected = new AtomicBoolean(false);
+        AtomicReference<String> callbackThread = new AtomicReference<>();
+
+        watch.watch(() -> {
+            detected.set(true);
+            callbackThread.set(Thread.currentThread().getName());
+        });
+
+        // create file after watcher is running
+        Files.writeString(dir.resolve("test.txt"), "data");
+
+        Thread.sleep(interval + 1000);
+        watch.stop();
+
+        assertTrue(detected.get(), "change should have been detected");
+        assertNotEquals(Thread.currentThread().getName(), callbackThread.get(), "callback should run on separate thread");
+    }
+}


### PR DESCRIPTION
## Summary
- add threaded watch behavior in `FolderWatch`
- create `FolderWatchTest` to verify detection and thread separation

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68435b369a6c83329a0ba286482d7299